### PR TITLE
zi80dis: remove gratuitous use of C++ and convert to pure C

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,20 +1,23 @@
 # On Mac OSX gcc is required as clang complains bitterly about the old style
 # C delarations used.
 
+# FIXME: parallel build doesn't work due to doc.inl
+
 CC=gcc
-CXX=g++
 DEP=zmac.o mio.o doc.o zi80dis.o
 
+HOSTCC ?= $(CC)
+
 # Some systems like CentOS may require this
-# YACC=bison -y
+YACC=bison -y
 # Is there a YACCFLAGS?
 
 zmac: doc.inl $(DEP)
-	$(CXX) -Wall $(CXXFLAGS) -o zmac $(DEP)
+	$(CC) -Wall $(CFLAGS) -o zmac $(DEP)
 
 doc.inl: doc.c doc.txt
-	$(CC) -Wall -DMK_DOC -o doc doc.c
+	$(HOSTCC) -Wall -DMK_DOC -o doc doc.c
 	./doc >/dev/null
 
 clean:
-	rm -f zmac.c doc.inl $(DEP)
+	rm -f doc zmac zmac.c doc.inl $(DEP)

--- a/src/zi80dis.h
+++ b/src/zi80dis.h
@@ -13,44 +13,45 @@
 // symbolic names as directed by the associated m_arg[] and m_argType[] values.
 //
 
-#if defined(__cplusplus)
+#include <stdbool.h>
 
-class Zi80dis
-{
-public:
-	Zi80dis();
+enum Processor {
+	proc8080,
+	procZ80,
+	procZ180
+};
 
-	// Don't re-order these or you'l break zmac.
-	enum Processor {
-		proc8080,
-		procZ80,
-		procZ180
-	};
+enum ArgType {
+	argByte,		// byte constant
+	argWord,		// word constant
+	argAddress,		// memory address
+	argRelative,	// relative jump (but value is a memory address not an offset)
+	argCall,		// call address
+	argRst,			// restart address
+	argIndex,		// IX or IY index offset
+	argPort			// I/O port
+};
 
-	void SetProcessor(Processor proc);	// default is procZ80
-	void SetAssemblerable(bool assemblerable); // default true, slightly alters Format() output
-	void SetDollarHex(bool dollarhex); // default false, prints hex constants with $ notation
-	void SetUndocumented(bool undoc); // default false, does not disassemble undocumented instructions
+enum AttrBit {
+	attrRead = 1,
+	attrWrite = 2,
+	attrByte = 4,
+	attrWord = 8,
+	attrIn = 16,
+	attrOut = 32,
+	attrJump = 64,
+	attrBranch = 128,
+	attrCall = 256,
+	attrRst = 512,
+	attrJumpReg = 1024
+};
 
-	void Disassemble(const unsigned char *mem, int pc, bool memPointsToInstruction = false);
-	void Format(char *outputBuffer);
 
-	bool IsUndefined();
-
-	enum ArgType {
-		argByte,		// byte constant
-		argWord,		// word constant
-		argAddress,		// memory address
-		argRelative,	// relative jump (but value is a memory address not an offset)
-		argCall,		// call address
-		argRst,			// restart address
-		argIndex,		// IX or IY index offset
-		argPort			// I/O port
-	};
+struct Zi80dis {
 
 	// Data resulting from call to Disassemble()
 
-	int	m_length;			// length of instruction in bytes
+	int m_length;			// length of instruction in bytes
 	int m_maxT;				// maximum number of T states to execute on z80
 	int m_minT;				// minimum number of T states to execute on z80
 	int m_max8080T;			// maximum number of T states to execute on 8080
@@ -61,37 +62,36 @@ public:
 	char m_format[16];		// format string for disassembly
 	int m_numArg;			// number of arguments
 	int m_arg[2];			// decoded arguments
-	ArgType m_argType[2];	// type of argument
+	enum ArgType m_argType[2];	// type of argument
 	bool m_neverNext;		// processor never proceeds to the following instruction
 	int m_stableMask;		// bit set for each byte of instruction invariant to relocation
 	int m_attrMask;			// bit set indicating read/write/byte/word/in/out/jp/jr/jp(rr) (see AttrBit)
 
-	enum AttrBit {
-		attrRead = 1,
-		attrWrite = 2,
-		attrByte = 4,
-		attrWord = 8,
-		attrIn = 16,
-		attrOut = 32,
-		attrJump = 64,
-		attrBranch = 128,
-		attrCall = 256,
-		attrRst = 512,
-		attrJumpReg = 1024
-	};
 
 	// Options.
 
-	Processor m_processor;
+	enum Processor m_processor;
 	bool m_assemblerable;
 	bool m_dollarhex;
 	bool m_undoc;
 };
 
-#else
+
+void Zi80dis_init(struct Zi80dis*);
+
+// Don't re-order these or you'l break zmac.
+
+void Zi80dis_SetProcessor(struct Zi80dis*, enum Processor proc);	// default is procZ80
+void Zi80dis_SetAssemblerable(struct Zi80dis*, bool assemblerable); // default true, slightly alters Format() output
+void Zi80dis_SetDollarHex(struct Zi80dis*, bool dollarhex); // default false, prints hex constants with $ notation
+void Zi80dis_SetUndocumented(struct Zi80dis*, bool undoc); // default false, does not disassemble undocumented instructions
+
+void Zi80dis_Disassemble(struct Zi80dis*, const unsigned char *mem, int pc, bool memPointsToInstruction);
+void Zi80dis_Format(struct Zi80dis*, char *outputBuffer);
+
+bool Zi80dis_IsUndefined(struct Zi80dis*);
 
 // For the one holdout still using C (zmac).
 
 int zi_tstates(const unsigned char *inst, int proc, int *low, int *high, int *ocf, char *disasm);
 
-#endif /* defined(__cplusplus) */


### PR DESCRIPTION
now everything can be compiled with a C compiler, which makes it simpler
to hack on, produce a smaller binary, and makes it more portable
(a C compiler exists for many more platforms than a C++ compiler, including
the TRS-80 itself.)