### PR TITLE
Macro80 fixes

### DIFF
--- a/src/zmac.y
+++ b/src/zmac.y
@@ -1998,6 +1998,7 @@ void do_defl(struct item *sym, struct expr *val, int call_list);
 %token NUL
 %token <itemptr> MPARM
 %token <itemptr> TK_IN0 TK_OUT0 MLT TST TSTIO
+%token LALL SALL XALL
 
 %type <itemptr> label.part symbol
 %type <ival> allreg reg evenreg ixylhreg realreg mem memxy pushable bcdesp bcdehl bcdehlsp mar condition
@@ -2587,6 +2588,7 @@ statement:
 			}
 			list1();
 			break;
+
 		case SPRINTX:
 			p = tempbuf;
 			quote = *p++;
@@ -2839,6 +2841,21 @@ statement:
 		// popsi() must be made safe as others use it.
 		list1();
 		popsi();
+	}
+|
+	LALL '\n' {
+		err[warn_notimpl]++;
+		list1();
+	}
+|
+	SALL '\n' {
+		err[warn_notimpl]++;
+		list1();
+	}
+|
+	XALL '\n' {
+		err[warn_notimpl]++;
+		list1();
 	}
 |
 	error {
@@ -4637,6 +4654,7 @@ struct	item	keytab[] = {
 	{"jrz",		0x28,	JR_COND,	VERB | Z80 | ZNONSTD },
 	{"jz",		0312,	JUMP8,		VERB | I8080 },
 	{"l",		5,	REGNAME,	I8080 | Z80 },
+	{".lall",	0,	LALL,		VERB | COL0 },
 	{"lbcd",	0xed4b,	LDST16,		VERB | Z80 | ZNONSTD },
 	{"ld",		0x40,	LD,		VERB | Z80 },
 	{"lda",		0x3a,	LDA,		VERB | I8080 },
@@ -4777,6 +4795,7 @@ struct	item	keytab[] = {
 	{"rst",		0307,	RST,		VERB | I8080 | Z80 },
 	{".rsym",	PSRSYM,	ARGPSEUDO,	VERB },
 	{"rz",		0310,	NOOPERAND,	VERB | I8080 },
+	{".sall",	0,	SALL,		VERB | COL0 },
 	{"sbb",		0230,	ARITHC,		VERB | I8080 },
 	{"sbc",		0230,	ARITHC,		VERB | Z80 },
 	{"sbcd",	0xed43,	LDST16,		VERB | Z80 | ZNONSTD },
@@ -4842,6 +4861,7 @@ struct	item	keytab[] = {
 	{"v",		050,	COND,		Z80 },
 	{".word",	0,	DEFW,		VERB },
 	{".wsym",	PSWSYM,	ARGPSEUDO,	VERB },
+	{".xall",	0,	XALL,		VERB | COL0 },
 	{"xchg",	0353,	NOOPERAND,	VERB | I8080 },
 	{"xh",   	0x1DD04,IXYLH,		Z80 | UNDOC },
 	{"xl",   	0x1DD05,IXYLH,		Z80 | UNDOC },

--- a/src/zmac.y
+++ b/src/zmac.y
@@ -624,6 +624,8 @@ char	*writesyms;
 
 char	*title;
 char	titlespace[TITLELEN];
+char	*subtitle;
+char	subtitlespace[TITLELEN];
 char	*timp;
 char	*sourcef;
 /* changed to cope with filenames longer than 14 chars -rjm 1998-12-15 */
@@ -1658,8 +1660,9 @@ void lineout()
 		line = 0;
 	}
 	if (line == 0) {
-		fprintf(fout, "\n\n%s %s\t%s\t Page %d\n\n\n",
-			&timp[4], &timp[20], title, page++);
+		fprintf(fout, "\n\n%s %s\t%s\t Page %d\n%s\n\n",
+			&timp[4], &timp[20], title, page++,
+			subtitle ? subtitle : "");
 		line = 4;
 	}
 	line++;
@@ -2533,7 +2536,14 @@ statement:
 			list1();
 			break;
 		case SPSBTL:
-			err[warn_notimpl]++;
+			cp = tempbuf;
+			subtitle = subtitlespace;
+			if (*cp == '\'' || *cp == '"')
+				quote = *cp++;
+			while ((*subtitle++ = *cp++) && (subtitle < &subtitlespace[TITLELEN]));
+			if (quote && subtitle > subtitlespace + 1 && subtitle[-2] == quote)
+				subtitle[-2] = '\0';
+			subtitle = subtitlespace;
 			list1();
 			break;
 		case SPNAME:
@@ -4800,7 +4810,7 @@ struct	item	keytab[] = {
 	{"stx",		0xdd70,	ST_XY,		VERB | Z80 | ZNONSTD},
 	{"sty",		0xfd70,	ST_XY,		VERB | Z80 | ZNONSTD},
 	{"sub",		0220,	LOGICAL,	VERB | I8080 | Z80 },
-	{".subttl",	SPSBTL,	SPECIAL,	VERB },
+	{".subttl",	SPSBTL,	SPECIAL,	VERB | COL0 },
 	{"subx",	0xdd96,	ALU_XY,		VERB | Z80 | ZNONSTD },
 	{"suby",	0xfd96,	ALU_XY,		VERB | Z80 | ZNONSTD },
 	{"sui",		0326,	ALUI8,		VERB | I8080 },

--- a/src/zmac.y
+++ b/src/zmac.y
@@ -1875,6 +1875,7 @@ void do_defl(struct item *sym, struct expr *val, int call_list);
 #define SPNAME	(2)	/* name */
 #define SPCOM	(3)	/* comment */
 #define SPPRAGMA (4)	/* pragma */
+#define SPRINTX (5)	/* printx */
 
 %}
 
@@ -2585,6 +2586,12 @@ statement:
 				fprintf(fmds, "%s\n", tempbuf + 4);
 			}
 			list1();
+			break;
+		case SPRINTX:
+			p = tempbuf;
+			quote = *p++;
+			q = strchr(p, quote);
+			printf("%.*s\n", (int)(q - p), p);
 			break;
 		}
 	}
@@ -4720,6 +4727,7 @@ struct	item	keytab[] = {
 	{"popix",	0xdde1,	NOOPERAND,	VERB | Z80 | ZNONSTD },
 	{"popiy",	0xfde1,	NOOPERAND,	VERB | Z80 | ZNONSTD },
 	{"pragma",	SPPRAGMA,SPECIAL,	VERB },
+	{".printx",	SPRINTX,	SPECIAL,	VERB | COL0 },
 	{"psw", 	060,	PSW,		I8080 },
 	{".public",	0,	PUBLIC,		VERB },
 	{"push",	0305,	PUSHPOP,	VERB | I8080 | Z80 },


### PR DESCRIPTION
Partial set of required fixes to allow zmac to build the Microsoft Basic-80 5.2 sources as available [here](https://winworldpc.com/download/c2bfc380-c2b2-c2b4-7d00-11c3a7c29d25).