### PR TITLE
Fix compilation errors reported by GCC 15.2

### DIFF
--- a/src/doc.txt
+++ b/src/doc.txt
@@ -1423,7 +1423,7 @@ Bruce Norskog originally wrote zmac in 1978.
 
 Updates and bugfixes over the years by John Providenza, Colin Kelley,
 and more recently by Russell Marks, Mark RISON, Chris Smith,
-Matthew Phillips and Tim Mann.
+Matthew Phillips, Tim Mann and Roman Standzikowski.
 
 Extensive modifications for cycle counting, multiple output formats,
 ".rel" output, 8080 mode and older assembler compatibilty were written

--- a/src/zmac.y
+++ b/src/zmac.y
@@ -236,6 +236,8 @@
  *		xh, xl, yh, yl, hx, lx, hy, ly alternates for ixh, ixy, iyh, iyl.
  *
  * gwp 21-1-24	%% expansion in macro to improve MRAS compatibility.
+ *
+ * rhs 28-1-26	Fix compilation errors reported by GCC 15.2.
  */
 
 #if defined(__GNUC__)
@@ -742,7 +744,7 @@ void putout(int value);
 int outrec;
 int outlen;
 unsigned char outbuf[1024 * 1024];
-void bookmark();
+void bookmark(int delay);
 void listfrombookmark();
 
 
@@ -5925,7 +5927,7 @@ int nextchar()
 {
 	int c, ch;
 	unsigned char *p;
-	char *getlocal();
+	char *getlocal(int c, int n);
 
 	if (peekc != NOPEEK) {
 		c = peekc;


### PR DESCRIPTION
I'm getting the following errors when compiling zmac with GCC 15.2 as a part of the https://github.com/MEGA65/open-roms project:

```
3rdparty/zmac/src/zmac.y: In function ‘delayed_list’:
3rdparty/zmac/src/zmac.y:1471:9: error: too many arguments to function ‘bookmark’; expected 0, have 1
 1471 |         bookmark(delay);
      |         ^~~~~~~~ ~~~~~
3rdparty/zmac/src/zmac.y:721:6: note: declared here
  721 | void bookmark();
      |      ^~~~~~~~
3rdparty/zmac/src/zmac.y: In function ‘delayed_list1’:
3rdparty/zmac/src/zmac.y:1750:9: error: too many arguments to function ‘bookmark’; expected 0, have 1
 1750 |         bookmark(delay);
      |         ^~~~~~~~ ~~~~~
3rdparty/zmac/src/zmac.y:721:6: note: declared here
  721 | void bookmark();
      |      ^~~~~~~~
3rdparty/zmac/src/zmac.y: In function ‘nextchar’:
3rdparty/zmac/src/zmac.y:5735:59: error: too many arguments to function ‘getlocal’; expected 0, have 2
 5735 |                                         strcpy((char *)p, getlocal(ch, est[TEMPNUM].value));
      |                                                           ^~~~~~~~ ~~
3rdparty/zmac/src/zmac.y:5642:15: note: declared here
 5642 |         char *getlocal();
      |               ^~~~~~~~
3rdparty/zmac/src/zmac.y: At top level:
3rdparty/zmac/src/zmac.y:7952:7: error: conflicting types for ‘getlocal’; have ‘char *(int,  int)’
 7952 | char *getlocal(int c, int n)
      |       ^~~~~~~~
3rdparty/zmac/src/zmac.y:5642:15: note: previous declaration of ‘getlocal’ with type ‘char *(void)’
 5642 |         char *getlocal();
      |               ^~~~~~~~
3rdparty/zmac/src/zmac.y:8325:6: error: conflicting types for ‘bookmark’; have ‘void(int)’
 8325 | void bookmark(int delay)
      |      ^~~~~~~~
3rdparty/zmac/src/zmac.y:721:6: note: previous declaration of ‘bookmark’ with type ‘void(void)’
  721 | void bookmark();
      |      ^~~~~~~~
```

This PR fixes the errors above.